### PR TITLE
Add missing parameters to Subscription.change_plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ LemonSqueezy::Subscription.cancel id: 123
 LemonSqueezy::Subscription.uncancel id: 123
 
 # Change the Plan for a Subscription
-LemonSqueezy::Subscription.change_plan id: 123, plan_id: 111, variant_id: 111
+# invoice_immediately and disable_prorations are optional and false by default.
+LemonSqueezy::Subscription.change_plan id: 123, plan_id: 111, variant_id: 111, invoice_immediately: false, disable_prorations: false
 ```
 
 ### Subscription Invoices

--- a/lib/lemon_squeezy/models/subscription.rb
+++ b/lib/lemon_squeezy/models/subscription.rb
@@ -77,14 +77,16 @@ module LemonSqueezy
         Subscription.new(response.body["data"]) if response.success?
       end
 
-      def change_plan(id:, plan_id:, variant_id:)
+      def change_plan(id:, plan_id:, variant_id:, invoice_immediately: false, disable_prorations: false)
         body = {
           data: {
             type: "subscriptions",
             id: id.to_s,
             attributes: {
               product_id: plan_id,
-              variant_id: variant_id
+              variant_id: variant_id,
+              invoice_immediately: invoice_immediately,
+              disable_prorations: disable_prorations
             }
           }
         }


### PR DESCRIPTION
I was wondering how to invoice immediately when changing a subscription plan because I read about the option to do so in the [upstream guide on changing plan](https://docs.lemonsqueezy.com/guides/tutorials/change-subscriber-plan). Then I saw that your neat library does not support that yet. So here is the PR adding the missing parameters.