### PR TITLE
Add Ruby 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ruby_4_support
 
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ruby_4_support
 
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in lemonsqueezy.gemspec
 gemspec
 
+gem "irb"
 gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     lemonsqueezy (1.1.0)
       faraday (~> 2.0)
+      ostruct (~> 0.6)
 
 GEM
   remote: https://rubygems.org/
@@ -21,6 +22,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
+    ostruct (0.6.3)
     rake (13.3.1)
     uri (1.0.3)
     vcr (6.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
+    base64 (0.3.0)
     dotenv (2.8.1)
-    faraday (2.12.2)
+    faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -17,15 +17,16 @@ GEM
       net-http (>= 0.5.0)
     json (2.10.2)
     logger (1.6.6)
-    minitest (5.20.0)
+    minitest (5.27.0)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
-    rake (13.1.0)
+    rake (13.3.1)
     uri (1.0.3)
-    vcr (6.2.0)
+    vcr (6.4.0)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    date (3.5.1)
     dotenv (2.8.1)
+    erb (6.0.1)
     faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    io-console (0.8.2)
+    irb (1.16.0)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.10.2)
     logger (1.6.6)
     minitest (5.27.0)
@@ -23,7 +30,21 @@ GEM
     net-http (0.6.0)
       uri
     ostruct (0.6.3)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.3.1)
+      date
+      stringio
     rake (13.3.1)
+    rdoc (7.1.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    reline (0.6.3)
+      io-console (~> 0.5)
+    stringio (3.2.0)
+    tsort (0.2.0)
     uri (1.0.3)
     vcr (6.4.0)
 
@@ -34,6 +55,7 @@ PLATFORMS
 DEPENDENCIES
   base64
   dotenv
+  irb
   lemonsqueezy!
   minitest (~> 5.0)
   mutex_m

--- a/lemonsqueezy.gemspec
+++ b/lemonsqueezy.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 2.0"
+  spec.add_dependency "ostruct", "~> 0.6"
 end


### PR DESCRIPTION
Hello 👋 

Firstly, thanks for creating this gem!

This PR updates the repository and the gem dependencies to support Ruby 4.0.

* Updates `ci.yml` to include a Ruby 4.0 build.
* `bundle update minitest` for Ruby 4 compatibility.
* Adds `irb` gem dependency to enable `bin/console` in the `Gemfile`.
* Adds `ostruct` gem dependency for general functionality in the `lemonsqueezy.gemspec`

Note: I have not bumped the Gem version.